### PR TITLE
feature/scrollbar-gradient

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4,7 +4,7 @@
 body {
   margin: 0;
   padding: 0;
-  font: 'Muli', 'Helvetica Neue', 'Helvectica', 'Arial', serif;
+  font-family: 'Muli', 'Helvetica Neue', 'Helvectica', 'Arial', serif;
   font-weight: 100;
   font-size: 1em;
   line-height: 1.5em;
@@ -13,6 +13,9 @@ body {
   overflow-x: hidden;
 }
 
+::-webkit-scrollbar {
+  width: 10px;
+}
 
 h1, h2, h3 {
   font-weight: 100;
@@ -205,7 +208,6 @@ footer {
 }
 
 @media screen and (max-width: 825px) {
-
   h1 {
     font-size: 2.25rem
   }
@@ -227,6 +229,7 @@ footer {
     grid-template-columns: repeat(3, 1fr);
     text-align: center;
   }
+
 
   h1 {
     font-size: 5em;

--- a/js/script.js
+++ b/js/script.js
@@ -60,11 +60,21 @@ const showAlert = () => {
         );
 };
 
-
-const printContent = content => {
+/**
+ * Set/Update root div depending on content
+ * Remove dynamically generated style element
+ * @param {String<HTML> | undefined} content
+ * @return void
+ */
+const setContent = content => {
     const rootDiv = document.getElementById("add-js");
+    const styles = document.head.getElementsByTagName("style");
+
     if (content) rootDiv.innerHTML += `${content}`;
-    else rootDiv.innerHTML = "";
+    else {
+        rootDiv.innerHTML = "";
+        styles.length && document.head.removeChild(styles[0]);
+    }
 };
 
 /**
@@ -107,9 +117,42 @@ const addCard = ({ red, green, blue }, center = false) => {
     `;
 };
 
-document.getElementById("submit").addEventListener("click", event => {
-    // reset shades
-    printContent();
+/**
+ * Apply dynamic styling to scrollbar
+ * return void
+ */
+const styleScrollBar = () => {
+    const colors = document.getElementsByClassName("colors");
+    const startColor = colors[0].style.backgroundColor;
+    const endColor = colors[colors.length - 1].style.backgroundColor;
+    const styleTag = document.createElement("style");
+
+    const trackStyle = `
+        :root {
+            scrollbar-color: ${startColor} ${endColor};
+        }
+
+        body::-webkit-scrollbar-track {
+            background: linear-gradient(0deg, ${endColor} 0%, ${startColor} 100%);
+        }
+
+        body::-webkit-scrollbar-thumb {
+            background: linear-gradient(0deg, ${endColor} 0%, ${startColor} 100%);
+        }
+
+    `;
+
+    styleTag.innerHTML = trackStyle;
+    document.head.insertAdjacentElement("beforeend", styleTag);
+};
+
+/**
+ * Generate page template with shades and scrollbar styles
+ * return void
+ */
+const pageGenerator = () => {
+    // reset shades & scrollbar styles
+    setContent();
 
     // Get user input for RGB values
     let content = "";
@@ -119,8 +162,8 @@ document.getElementById("submit").addEventListener("click", event => {
 
     const allValid = valuesValidators(colors, values);
     if (!allValid) {
+        setContent();
         showAlert();
-        printContent();
         return;
     }
 
@@ -148,8 +191,10 @@ document.getElementById("submit").addEventListener("click", event => {
         blue += 2;
     }
 
-    // Display all content in root div
+    // Render all content/styles
     content += `</div>`;
-    printContent(content);
-});
+    setContent(content);
+    styleScrollBar();
+};
 
+document.getElementById("submit").addEventListener("click", pageGenerator);


### PR DESCRIPTION
**Note**: This PR is rebased off of #29 so it would wise to merge that one in prior to this one.

Dynamically generate scrollbar styles based on card colors. Note that scrollbar styles are only supported on blink and webkit based browsers like chrome & safari. 
~~Firefox doesn't seem to be supported currently in my estimation as tested on FireFox Developer Edition.~~

Updated with Firefox's `scrollbar-color` property, however it doesn't allow using a linear-gradient
color so colors are the first card color for the track and the last card color for the thumb.

Feel free to adjust the styling to your liking.

closes #22  